### PR TITLE
Fix whitelist matching for anchor players

### DIFF
--- a/sanguine_cog.py
+++ b/sanguine_cog.py
@@ -280,9 +280,22 @@ def matchmaking_algorithm(available_raiders: List[Dict[str, Any]]):
             if pool:
                 anchor = pool.pop(0)
                 break
-        
+
         if anchor:
             teams.append([anchor])
+
+            # Immediately add any players with mutual whitelists to this team
+            all_pools = [mentors, strong_pool, learners, news, mentees]
+            for pool in all_pools:
+                players_to_add = []
+                for player in pool:
+                    if is_whitelist_match(anchor, player):
+                        players_to_add.append(player)
+
+                for player in players_to_add:
+                    if len(teams[i]) < target_size and not is_blacklist_violation(player, teams[i]):
+                        teams[i].append(player)
+                        pool.remove(player)
         else:
             teams.append([])
 


### PR DESCRIPTION
When two players with mutual whitelists are both in the strong pool, they were both becoming anchors on separate teams. The whitelist matching only worked when distributing leftovers, so they never got placed together.

Now, immediately after selecting an anchor, the algorithm checks all remaining pools for mutual whitelist matches and adds them to the anchor's team right away. This ensures whitelisted pairs stay together regardless of their skill level.