### PR TITLE
Add Member role permissions to auto-created voice channels

### DIFF
--- a/sanguine_cog.py
+++ b/sanguine_cog.py
@@ -1437,15 +1437,25 @@ class SanguineCog(commands.Cog):
         created_vcs = []
         
         if category and isinstance(category, discord.CategoryChannel):
+            # Set up permissions for Member role
+            member_role = guild.get_role(MEMBER_ROLE_ID)
+            overwrites = {}
+            if member_role:
+                overwrites[member_role] = discord.PermissionOverwrite(
+                    view_channel=True,
+                    connect=True,
+                    speak=True
+                )
+
             for i, team in enumerate(teams):
                 try:
                     mentor_name = f"Team{i+1}"
                     if team: # Make sure team is not empty
                         # First player in sorted team is the anchor/mentor
                         mentor_name = sanitize_nickname(team[0].get("user_name", mentor_name))
-                    
+
                     vc_name = f"SanSun{mentor_name}"
-                    new_vc = await category.create_voice_channel(name=vc_name)
+                    new_vc = await category.create_voice_channel(name=vc_name, overwrites=overwrites)
                     created_vcs.append(new_vc)
                 except Exception as e:
                     print(f"Error creating VC: {e}") 


### PR DESCRIPTION
When creating team voice channels via /sangmatch, the channels now have permission overwrites that allow the Member role to:
- View the channel
- Connect to the channel
- Speak in the channel

This ensures all clan members can see and join the team VCs.