### PR TITLE
Fix clan coffer calculation to include CEO bank

### DIFF
--- a/main.py
+++ b/main.py
@@ -1362,10 +1362,8 @@ def get_current_total_and_holders_and_owed():
 
         if entry_type == "deposit":
             total += amount
-            inferred_holders[name] = inferred_holders.get(name, 0) + amount
         elif entry_type == "withdraw":
             total -= amount
-            inferred_holders[name] = inferred_holders.get(name, 0) - amount
 
     for row in records:
         name = row.get("Name")


### PR DESCRIPTION
CEO Bank should only show net deposits/withdrawals, while Held should only show actual "holding" entries. Previously, deposits were being added to both total and inferred_holders, causing double-counting in the clan coffer total.